### PR TITLE
Populate notGitOnly when retrieving source code

### DIFF
--- a/src/server/router/submission.js
+++ b/src/server/router/submission.js
@@ -101,7 +101,7 @@ router.get('/sourceCode/:id', requireLogin, wrap(async (req, res) => {
   if (isNaN(req.params.id)) return res.status(400).send('id must be a number');
   const id = req.params.id;
   const submission = await Submission.findById(id)
-    .populate('problem', 'resource visible')
+    .populate('problem', 'resource visible notGitOnly')
     ;
 
   if (!submission) return res.status(404).send(`Submission ${id} not found.`);


### PR DESCRIPTION
It is required by the check `!(req.user && (req.user.isAdmin() || req.user.isTA())) &&
        !((ids.find(id => submission.submittedBy.equals(id)) && submission.problem.visible && submission.problem.notGitOnly) || submission.problem.resource.includes('solution')` below.