### PR TITLE
Give rejudge a lower priority

### DIFF
--- a/src/client/js/components/diff/index.js
+++ b/src/client/js/components/diff/index.js
@@ -46,8 +46,8 @@ export default Vue.extend({
     async fetch () {
       await this.getSubmission();
 
-      while (this.submission.status === 'pending' || this.submission.status === 'judging' ||
-                this.submission2.status === 'pending' || this.submission2.status === 'judging') {
+      while (this.submission.status === 'pending' || this.submission.status == 'pending-rejudge' || this.submission.status === 'judging' ||
+                this.submission2.status === 'pending' || this.submission2.status == 'pending-rejudge' || this.submission2.status === 'judging') {
         await sleep(2000);
         await this.getSubmission();
       }
@@ -120,6 +120,7 @@ export default Vue.extend({
       this.submission = data;
       this.showResult = (this.submission &&
                 this.submission.status !== 'pending' &&
+	        this.submission.status !== 'pending-rejudge' &&
                 this.submission.result !== 'CE');
 
       const data2 = _result2.data;
@@ -145,12 +146,13 @@ export default Vue.extend({
       this.submission2 = data2;
       this.showResult2 = (this.submission2 &&
                 this.submission2.status !== 'pending' &&
+	        this.submission2.status !== 'pending-rejudge' &&
                 this.submission2.result !== 'CE');
     },
     async queryChanged () {
       await this.getSubmission();
-      while (this.submission.status === 'pending' || this.submission.status === 'judging' ||
-                this.submission2.status === 'pending' || this.submission2.status === 'judging') {
+      while (this.submission.status === 'pending' || this.submission.status === 'pending-rejudge' || this.submission.status === 'judging' ||
+                this.submission2.status === 'pending' || this.submission2.status === 'pending-rejudge' || this.submission2.status === 'judging') {
         await sleep(2000);
         await this.getSubmission();
       }

--- a/src/client/js/components/submission/index.js
+++ b/src/client/js/components/submission/index.js
@@ -44,7 +44,7 @@ export default Vue.extend({
     async fetch () {
       await this.getSubmission();
 
-      while (this.submission.status === 'pending' || this.submission.status === 'judging') {
+      while (this.submission.status === 'pending' || this.submission.status === 'pending-rejudge' || this.submission.status === 'judging') {
         await sleep(2000);
         await this.getSubmission();
       }
@@ -97,6 +97,7 @@ export default Vue.extend({
       this.submission = data;
       this.showResult = (this.submission &&
                 this.submission.status !== 'pending' &&
+                this.submission.status !== 'pending-rejudge' &&
                 this.submission.result !== 'CE');
     }
   },

--- a/src/client/js/filters.js
+++ b/src/client/js/filters.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 
 Vue.filter('toFormattedTime', (val, fmt) => moment(val).tz('Asia/Taipei').format(fmt));
 Vue.filter('toResultString', (val) => {
-    if (val === 'pending' || val === 'judging') return val;
+    if (val === 'pending' || val === 'pending-rejudge' || val === 'judging') return val;
     return {
         'PE': 'Presentation Error',
         'JE': 'Judge Error',

--- a/src/client/js/probUtils.js
+++ b/src/client/js/probUtils.js
@@ -33,6 +33,7 @@ export function getResultString(sub, toHuman=true) {
         if (toHuman)
             return {
                 'pending': 'Pending',
+		'pending-rejudge': 'Pending',
                 'judging': 'Judging',
                 'error': 'Judge Error',
             }[sub.status];

--- a/src/server/judger/index.js
+++ b/src/server/judger/index.js
@@ -77,10 +77,16 @@ async function mainLoop () {
     workers.push(new Worker(i));
   }
   while (true) {
-    const pending = await (
-      Submission.findOne({status: 'pending'})
+    let pending = await (
+      Submission.findOne({status: 'pending-rejudge'})
         .populate('problem')
     );
+    if (!pending) {
+      pending = await (
+        Submission.findOne({status: 'pending'})
+          .populate('problem')
+      );
+    }
     if (!pending) {
       await sleep(1000);
       continue;

--- a/src/server/judger/index.js
+++ b/src/server/judger/index.js
@@ -78,12 +78,12 @@ async function mainLoop () {
   }
   while (true) {
     let pending = await (
-      Submission.findOne({status: 'pending-rejudge'})
+      Submission.findOne({status: 'pending'})
         .populate('problem')
     );
     if (!pending) {
       pending = await (
-        Submission.findOne({status: 'pending'})
+        Submission.findOne({status: 'pending-rejudge'})
           .populate('problem')
       );
     }

--- a/src/server/router/admin/problem.js
+++ b/src/server/router/admin/problem.js
@@ -179,7 +179,7 @@ router.post('/:id/rejudge', wrap(async (req, res) => {
     await Submission.update(
       {problem: req.params.id},
       {
-        $set: {'status': 'pending', 'result': null},
+        $set: {'status': 'pending-rejudge', 'result': null},
         $unset: {'runtime': ''}
       },
       {multi: true}

--- a/src/server/router/admin/submission.js
+++ b/src/server/router/admin/submission.js
@@ -59,7 +59,7 @@ router.get('/:id/rejudge', wrap(async (req, res) => {
     let sub = await Submission.findOneAndUpdate(
       {'_id': req.params.id},
       {
-        $set: {'status': 'pending', 'result': null},
+        $set: {'status': 'pending-rejudge', 'result': null},
         $unset: {'runtime': ''}
       }
     );

--- a/src/server/statistic/problem.js
+++ b/src/server/statistic/problem.js
@@ -48,7 +48,7 @@ export async function getProblemResultBucket(problemID) {
             $match: {
                 'problem': problemID,
                 '_user.roles': 'student',
-                'status': { $nin: ['pending', 'judging'] },
+                'status': { $nin: ['pending', 'pending-rejudge', 'judging'] },
             },
         },
         {


### PR DESCRIPTION
- Rejudged submissions will have status 'pending-rejudge', and the
  workers will try to grab 'pending' submissions before
  'pending-rejudge' ones.